### PR TITLE
added depth to album_serializer.py and song_serializer.py

### DIFF
--- a/music_history_api/serializers/album_serializer.py
+++ b/music_history_api/serializers/album_serializer.py
@@ -14,3 +14,5 @@ class AlbumSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = album_model.Album
         fields = '__all__'
+        depth = 2
+

--- a/music_history_api/serializers/song_serializer.py
+++ b/music_history_api/serializers/song_serializer.py
@@ -14,3 +14,4 @@ class SongSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = song_model.Song
         fields = '__all__'
+        depth = 1


### PR DESCRIPTION
# Description
This fixes the multiple call requirement to obtain all data for an album or song.

# Related Ticket(s)
fixes #21 

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[X] I certify that all existing tests pass

## Documentation

[ ] There is new documentation in this pull request that must be reviewed..

## Deploy Notes


## Steps to Test
1. start `python manage.py runserver`
1. navigate to an [artist](http://localhost:8000/api/artist) or [album](http://localhost:8000/api/album) page
